### PR TITLE
Feat: sign up 페이지 구현

### DIFF
--- a/src/components/SignupForm/SignupForm.tsx
+++ b/src/components/SignupForm/SignupForm.tsx
@@ -32,7 +32,7 @@ function SignupForm({ handleSubmitForm, handleChangeForm, error }: Props) {
           required
           variant="outlined"
           id="email"
-          name="emailField"
+          name="email"
           label="email"
           placeholder="email"
           fullWidth
@@ -45,7 +45,7 @@ function SignupForm({ handleSubmitForm, handleChangeForm, error }: Props) {
           required
           variant="outlined"
           id="password"
-          name="passwordField"
+          name="password"
           label="Password"
           type="password"
           fullWidth
@@ -58,7 +58,7 @@ function SignupForm({ handleSubmitForm, handleChangeForm, error }: Props) {
           required
           variant="outlined"
           id="passwordConfirm"
-          name="passwordConfirmField"
+          name="passwordConfirm"
           label="PasswordConfirm"
           type="password"
           fullWidth

--- a/src/components/SignupForm/SignupForm.tsx
+++ b/src/components/SignupForm/SignupForm.tsx
@@ -31,6 +31,7 @@ function SignupForm({ handleSubmitForm, handleChangeForm, errors }: Props) {
         <TextField
           required
           variant="outlined"
+          sx={{ label: { fontSize: '1.2rem' } }}
           id="email"
           name="email"
           label="email"
@@ -44,6 +45,7 @@ function SignupForm({ handleSubmitForm, handleChangeForm, errors }: Props) {
         <TextField
           required
           variant="outlined"
+          sx={{ label: { fontSize: '1.2rem' } }}
           id="password"
           name="password"
           label="Password"
@@ -57,6 +59,7 @@ function SignupForm({ handleSubmitForm, handleChangeForm, errors }: Props) {
         <TextField
           required
           variant="outlined"
+          sx={{ label: { fontSize: '1.2rem' } }}
           id="passwordConfirm"
           name="passwordConfirm"
           label="PasswordConfirm"

--- a/src/components/SignupForm/SignupForm.tsx
+++ b/src/components/SignupForm/SignupForm.tsx
@@ -1,4 +1,4 @@
-import { SignupFieldError } from '@/types';
+import { AuthError } from '@/types';
 import { css } from '@emotion/react';
 import { TextField } from '@mui/material';
 import { InputContainer, SubmitButton, ErrorMessage } from './signupFormStyle';
@@ -6,10 +6,10 @@ import { InputContainer, SubmitButton, ErrorMessage } from './signupFormStyle';
 interface Props {
   handleSubmitForm: React.FormEventHandler<HTMLFormElement>;
   handleChangeForm: React.FormEventHandler<HTMLFormElement>;
-  error: SignupFieldError;
+  errors: AuthError;
 }
 
-function SignupForm({ handleSubmitForm, handleChangeForm, error }: Props) {
+function SignupForm({ handleSubmitForm, handleChangeForm, errors }: Props) {
   return (
     <form
       css={css`
@@ -36,9 +36,9 @@ function SignupForm({ handleSubmitForm, handleChangeForm, error }: Props) {
           label="email"
           placeholder="email"
           fullWidth
-          error={!!error.emailErrorMessage}
+          error={!!errors.email}
         />
-        <ErrorMessage>{error.emailErrorMessage}</ErrorMessage>
+        <ErrorMessage>{errors.email}</ErrorMessage>
       </InputContainer>
       <InputContainer>
         <TextField
@@ -49,9 +49,9 @@ function SignupForm({ handleSubmitForm, handleChangeForm, error }: Props) {
           label="Password"
           type="password"
           fullWidth
-          error={!!error.passwordErrorMessage}
+          error={!!errors.password}
         />
-        <ErrorMessage>{error.passwordErrorMessage}</ErrorMessage>
+        <ErrorMessage>{errors.password}</ErrorMessage>
       </InputContainer>
       <InputContainer>
         <TextField
@@ -62,18 +62,18 @@ function SignupForm({ handleSubmitForm, handleChangeForm, error }: Props) {
           label="PasswordConfirm"
           type="password"
           fullWidth
-          error={!!error.passwordConfirmErrorMessage}
+          error={!!errors.passwordConfirm}
         />
-        <ErrorMessage>{error.passwordConfirmErrorMessage}</ErrorMessage>
+        <ErrorMessage>{errors.passwordConfirm}</ErrorMessage>
       </InputContainer>
       <SubmitButton
         type="submit"
         variant="outlined"
         name="submit"
         disabled={
-          error.emailErrorMessage !== null ||
-          error.passwordErrorMessage !== null ||
-          error.passwordConfirmErrorMessage !== null
+          typeof errors.email === 'string' ||
+          typeof errors.password === 'string' ||
+          typeof errors.passwordConfirm === 'string'
         }
         disableElevation
       >

--- a/src/components/SignupForm/signupFormStyle.ts
+++ b/src/components/SignupForm/signupFormStyle.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { TextField, Button } from '@mui/material';
 
 export const InputContainer = styled.div`
-  height: 90px;
+  height: 8rem;
 `;
 
 export const SubmitButton = styled(Button)`
@@ -11,7 +11,7 @@ export const SubmitButton = styled(Button)`
 `;
 
 export const ErrorMessage = styled.span`
-  font-size: 10px;
+  font-size: 1.2rem;
   color: red;
-  margin-bottom: 10px;
+  margin-bottom: 1rem;
 `;

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -26,7 +26,10 @@ function useForm({ initialFormValues, submittingFunction }: Props) {
     const target = event.target as HTMLInputElement;
 
     setFormInputValues((previousValues) => ({ ...previousValues, [target.name]: target.value }));
-    setErrors(validateForm(formInputValues, errors, target.name));
+
+    setErrors(
+      validateForm({ ...formInputValues, [target.name]: target.value }, errors, target.name)
+    );
   };
 
   const handleSubmitForm = (event: React.FormEvent<HTMLFormElement>) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Global } from '@emotion/react';
+import { ThemeProvider } from '@mui/material';
 import { AuthProvider } from './context';
 import App from './App';
-import { reset } from './styles';
+import { reset, muiTheme } from './styles';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <Global styles={reset} />
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <ThemeProvider theme={muiTheme}>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -1,93 +1,22 @@
-import { useState } from 'react';
+import { useContext } from 'react';
 import { AxiosError } from 'axios';
 import { css } from '@emotion/react';
+import { AuthContext } from '@/context';
 import { signup } from '@/apis';
-import { SignupForm } from '@/components/index';
-import { setLocalStorage } from '@/utils';
-import { SignupFieldError } from '@/types';
-import { ACCESS_TOKEN, HTTP_ERRORS } from '@/consts';
-
-const ERROR_TYPE = {
-  INVALID_EMAIL: 'invalidEmail',
-  INVALID_PASSWORD: 'invalidPassword',
-  DIFFERENT_PASSWORD: 'differentPassword',
-} as const;
-
-const ERROR_MESSAGE = {
-  invalidEmail: '이메일 형식에 맞게 작성해주세요.',
-  invalidPassword: '비밀번호는 8자리 이상 입력해주세요.',
-  differentPassword: '동일한 비밀번호를 작성해주세요.',
-};
+import { useForm } from '@/hooks';
+import { HTTP_ERRORS } from '@/consts';
+import { SignupForm } from '@/components';
 
 function Signup() {
-  const [signupFieldErrorMessage, setSignupFieldErrorMessage] = useState<SignupFieldError>({
-    emailErrorMessage: '',
-    passwordErrorMessage: '',
-    passwordConfirmErrorMessage: '',
-  });
+  const { setToken } = useContext(AuthContext);
 
-  const checkEmailErrorMessage = (email: string) => {
-    const EMAIL_REGEX =
-      /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
-
-    if (!EMAIL_REGEX.test(email)) {
-      return ERROR_MESSAGE[ERROR_TYPE.INVALID_EMAIL];
-    }
-
-    return null;
-  };
-
-  const checkPasswordsErrorMessage = (
-    password: string,
-    passwordConfirm: string
-  ): { passwordErrorMessage: string | null; passwordConfirmErrorMessage: string | null } => {
-    const MIN_PASSWORD_LENGTH = 8;
-
-    if (0 < password.length && password.length < MIN_PASSWORD_LENGTH) {
-      return {
-        passwordErrorMessage: '8자리 이상 입력해주세요',
-        passwordConfirmErrorMessage: null,
-      };
-    }
-
-    if (
-      password.length >= MIN_PASSWORD_LENGTH &&
-      passwordConfirm.length > 0 &&
-      password !== passwordConfirm
-    ) {
-      return {
-        passwordErrorMessage: '동일한 비밀번호를 입력해주세요.',
-        passwordConfirmErrorMessage: '동일한 비밀번호를 입력해주세요.',
-      };
-    }
-
-    if (password.length === 0 || passwordConfirm.length === 0) {
-      return {
-        passwordErrorMessage: '',
-        passwordConfirmErrorMessage: '',
-      };
-    }
-
-    return {
-      passwordErrorMessage: null,
-      passwordConfirmErrorMessage: null,
-    };
-  };
-
-  const handleSubmitForm = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const { emailField, passwordField } = event.currentTarget;
-
-    const email = emailField.value;
-    const password = passwordField.value;
-
+  const register = async () => {
     try {
       const {
         data: { message, token },
-      } = await signup({ email, password });
+      } = await signup(formInputValues);
 
-      await setLocalStorage(ACCESS_TOKEN, token);
+      setToken(token);
 
       alert(message);
     } catch (error) {
@@ -101,32 +30,10 @@ function Signup() {
     }
   };
 
-  const handleChangeForm = (event: React.FormEvent<HTMLFormElement>) => {
-    const target = event.target as HTMLInputElement;
-
-    const { emailField, passwordField, passwordConfirmField } = event.currentTarget;
-
-    const emailErrorMessage = checkEmailErrorMessage(emailField.value);
-    const { passwordErrorMessage, passwordConfirmErrorMessage } = checkPasswordsErrorMessage(
-      passwordField.value,
-      passwordConfirmField.value
-    );
-
-    if (target.name === 'emailField') {
-      setSignupFieldErrorMessage((previousError) => ({
-        ...previousError,
-        emailErrorMessage,
-      }));
-    }
-
-    if (target.name === 'passwordField' || target.name === 'passwordConfirmField') {
-      setSignupFieldErrorMessage((previousError) => ({
-        ...previousError,
-        passwordErrorMessage,
-        passwordConfirmErrorMessage,
-      }));
-    }
-  };
+  const { formInputValues, errors, handleChangeForm, handleSubmitForm } = useForm({
+    initialFormValues: { email: '', password: '', passwordConfirm: '' },
+    submittingFunction: register,
+  });
 
   return (
     <div
@@ -141,7 +48,7 @@ function Signup() {
       <SignupForm
         handleSubmitForm={handleSubmitForm}
         handleChangeForm={handleChangeForm}
-        error={signupFieldErrorMessage}
+        errors={errors}
       />
     </div>
   );

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,2 +1,3 @@
 export { default as reset } from './reset';
 export * from './common';
+export * from './theme';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,7 @@
+import { createTheme } from '@mui/material/styles';
+
+export const muiTheme = createTheme({
+  typography: {
+    fontFamily: 'Gowun Dodum, sans-serif',
+  },
+});

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,9 +1,3 @@
-export interface SignupFieldError {
-  emailErrorMessage?: string | null;
-  passwordErrorMessage?: string | null;
-  passwordConfirmErrorMessage?: string | null;
-}
-
 export interface AuthField {
   email: string;
   password: string;

--- a/src/utils/validateForm.ts
+++ b/src/utils/validateForm.ts
@@ -17,18 +17,18 @@ const validateEmail = (email: string, errors: AuthError) => {
 const validatePasswords = (password: string, errors: AuthError, passwordConfirm?: string) => {
   const MINIMUM_PASSWORD_LENGTH = 8;
 
-  if (password.length === 0) {
-    errors.password = '비밀번호를 입력해주세요.';
-    return errors;
-  }
-
-  if (0 <= password.length && password.length < MINIMUM_PASSWORD_LENGTH) {
-    errors.password = '비밀번호는 8자리 이상 입력해주세요.';
-    return errors;
-  }
+  if (password.length >= MINIMUM_PASSWORD_LENGTH) delete errors.password;
 
   if (passwordConfirm && password !== passwordConfirm) {
+    if (password && password.length < MINIMUM_PASSWORD_LENGTH)
+      errors.password = '비밀번호는 8자리 이상 입력해주세요.';
+
     errors.passwordConfirm = '비밀번호가 일치하지 않습니다.';
+    return errors;
+  }
+
+  if (password.length < MINIMUM_PASSWORD_LENGTH) {
+    errors.password = '비밀번호는 8자리 이상 입력해주세요.';
     return errors;
   }
 

--- a/src/utils/validateForm.ts
+++ b/src/utils/validateForm.ts
@@ -27,12 +27,8 @@ const validatePasswords = (password: string, errors: AuthError, passwordConfirm?
     return errors;
   }
 
-  if (
-    passwordConfirm &&
-    0 <= passwordConfirm.length &&
-    passwordConfirm.length < MINIMUM_PASSWORD_LENGTH
-  ) {
-    errors.passwordConfirm = '비밀번호는 8자리 이상 입력해주세요.';
+  if (passwordConfirm && password !== passwordConfirm) {
+    errors.passwordConfirm = '비밀번호가 일치하지 않습니다.';
     return errors;
   }
 


### PR DESCRIPTION
## 작업 사항
- mui를 사용하여 sign up 페이지 구현 7b7a4f1
<img width="660" alt="스크린샷 2023-01-30 오후 6 25 58" src="https://user-images.githubusercontent.com/61978339/215438172-7179b93b-6126-4046-8e12-56838cf06e22.png"></br>
- pages/Signup 컴포넌트 내부에서 input 값을 validate하여 에러 메시지 전달 
<img width="660" alt="스크린샷 2023-01-30 오후 6 31 27" src="https://user-images.githubusercontent.com/61978339/215439433-bd2e50ab-b32f-4bfe-ac7c-a9448fb64399.png"></br>
 이후, sign in 페이지 작업 후 useForm을 이용하여 validate 하는 것으로 변경 edaf3c4
- password와 passwordConfirm 비교하는 validation 로직 추가 93ee310
- mui theme provider를 사용하여 폰트 설정 19db1d0


## 궁금한 부분
- 어떻게 해야 validatePasswords 내부에서 깔끔하게 검증할 수 있을지 모르겠다.
- mui component 사용하고 label 스타일을 변경할때 지금은 `sx={{ label: { fontSize: '1.2rem' } }}` 이렇게 인라인으로 주고 있는데 차라리 공통 컴포넌트 분리하는게 좋을지 모르겠다.
